### PR TITLE
Upgrade to .NET 8 and Avalonia 11

### DIFF
--- a/App.axaml
+++ b/App.axaml
@@ -2,6 +2,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="YoutubeDownloader.App">
     <Application.Styles>
-        <FluentTheme Mode="Light"/>
+        <FluentTheme />
     </Application.Styles>
 </Application>

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -32,29 +32,19 @@ namespace YoutubeDownloader
                 var pathData = File.ReadAllText(fileContainingSavePath).Trim();
                 if (Directory.Exists(pathData))
                 {
-                    var saveFolderTextBox = GetControl<TextBox>("SaveFolder");
+                    var saveFolderTextBox = SaveFolder;
                     saveFolderTextBox.Text = pathData;
                 }
             }
         }
 
-        /// <summary>
-        /// Gets a control, given its name and type; otherwise, throws.
-        /// </summary>
-        private T GetControl<T>(string name) where T : class, IControl
-        {
-            return this.FindControl<T>(name)
-                ?? throw new InvalidOperationException(
-                    $"Could not find control \"{name}\" of type {typeof(T).FullName}.");
-        }
-
         private async void OnDownloadButton_Click(object sender, RoutedEventArgs e)
         {
-            var urlPartTextBox = GetControl<TextBox>("Url");
-            var log = GetControl<TextBlock>("Log");
+            var urlPartTextBox = Url;
+            var log = Log;
             log.Text = string.Empty;
 
-            var saveFolderTextBox = GetControl<TextBox>("SaveFolder");
+            var saveFolderTextBox = SaveFolder;
             if (string.IsNullOrWhiteSpace(saveFolderTextBox.Text))
             {
                 log.Text += "ERROR: An output directory must be entered\n";
@@ -69,7 +59,7 @@ namespace YoutubeDownloader
                 return;
             }
 
-            var playlistControl = GetControl<CheckBox>("DownloadPlaylist");
+            var playlistControl = DownloadPlaylist;
             Download downloadInfo = playlistControl!.IsChecked == true
                 ? new PlaylistDownload(urlPart)
                 : new VideoDownload(urlPart);
@@ -100,7 +90,7 @@ namespace YoutubeDownloader
             }
 
             // Rename, if requested.
-            var newFileName = GetControl<TextBox>("FileName");
+            var newFileName = FileName;
             if (string.IsNullOrWhiteSpace(newFileName?.Text))
                 return;
 
@@ -115,18 +105,18 @@ namespace YoutubeDownloader
         /// <returns>A return code from the external program.</returns>
         private async Task<int?> DownloadMediaAsync(Download downloadData)
         {
-            var log = GetControl<TextBlock>("Log");
+            var log = Log;
 
             var args = "--extract-audio --audio-format mp3 --audio-quality 0";
 
-            var splitChapters = GetControl<CheckBox>("SplitChapters");
+            var splitChapters = SplitChapters;
             if (splitChapters!.IsChecked == true)
             {
                 args += " --split-chapters";
                 log.Text += "Split Chapters is ON\n";
             }
 
-            var playlist = GetControl<CheckBox>("DownloadPlaylist");
+            var playlist = DownloadPlaylist;
             if (playlist!.IsChecked == true)
             {
                 args += " --yes-playlist";
@@ -134,7 +124,7 @@ namespace YoutubeDownloader
             }
 
             string directory;
-            var saveFolderTextBox = GetControl<TextBox>("SaveFolder");
+            var saveFolderTextBox = SaveFolder;
             if (string.IsNullOrWhiteSpace(saveFolderTextBox.Text))
             {
                 log.Text += "ERROR: You must enter a folder path.\n";
@@ -185,7 +175,7 @@ namespace YoutubeDownloader
         {
             GuardClauses();
 
-            var log = GetControl<TextBlock>("Log");
+            var log = Log;
 
             log.Text += $"Renaming file with video ID \"{mediaId}\" to \"{newFileName}\"...\n";
 

--- a/Youtube-Downloader.csproj
+++ b/Youtube-Downloader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>
@@ -16,10 +16,10 @@
     <TrimmableAssembly Include="Avalonia.Themes.Default"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.3"/>
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.3"/>
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.3"/>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.3"/>
+    <PackageReference Include="Avalonia" Version="11.0.9"/>
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.9"/>
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.9"/>
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.9"/>
     <AvaloniaResource Include="icon.png"/>
   </ItemGroup>
 </Project>

--- a/Youtube-Downloader.csproj
+++ b/Youtube-Downloader.csproj
@@ -16,10 +16,10 @@
     <TrimmableAssembly Include="Avalonia.Themes.Default"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.18"/>
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.18"/>
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.18"/>
-    <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4"/>
+    <PackageReference Include="Avalonia" Version="11.0.3"/>
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.3"/>
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.3"/>
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.3"/>
     <AvaloniaResource Include="icon.png"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I don't use this tool anymore since developing [CCVTAC](https://github.com/codeconscious/ccvtac), but I decided to upgrade this to .NET 8 and Avalonia 11 anyway.

Interestingly, the Avalonia upgrade means that `GetControl()` calls are no longer needed.

Ultimately, I might merge this into CCVTAC and develop it a bit further so that there are console and GUI versions of CCVTAC applications with a common library. We shall see...